### PR TITLE
C4 audit: resolve issue #182

### DIFF
--- a/src/vaults/AutoPxGlp.sol
+++ b/src/vaults/AutoPxGlp.sol
@@ -130,6 +130,10 @@ contract AutoPxGlp is PirexERC4626, PxGmxReward, ReentrancyGuard {
     function setPlatform(address _platform) external onlyOwner {
         if (_platform == address(0)) revert ZeroAddress();
 
+        // Update base reward transfer allowance for the old and new platforms
+        gmxBaseReward.safeApprove(platform, 0);
+        gmxBaseReward.safeApprove(_platform, type(uint256).max);
+
         platform = _platform;
 
         emit PlatformUpdated(_platform);

--- a/src/vaults/AutoPxGmx.sol
+++ b/src/vaults/AutoPxGmx.sol
@@ -152,6 +152,10 @@ contract AutoPxGmx is ReentrancyGuard, Owned, PirexERC4626 {
     function setPlatform(address _platform) external onlyOwner {
         if (_platform == address(0)) revert ZeroAddress();
 
+        // Update GMX transfer allowance for the old and new platforms
+        gmx.safeApprove(platform, 0);
+        gmx.safeApprove(_platform, type(uint256).max);
+
         platform = _platform;
 
         emit PlatformUpdated(_platform);

--- a/test/AutoPxGlp.t.sol
+++ b/test/AutoPxGlp.t.sol
@@ -531,6 +531,8 @@ contract AutoPxGlpTest is Helper {
 
         assertEq(expectedPlatform, autoPxGlp.platform());
         assertTrue(expectedPlatform != initialPlatform);
+        assertEq(0, weth.allowance(address(autoPxGlp), initialPlatform));
+        assertEq(type(uint256).max, weth.allowance(address(autoPxGlp), platform));
     }
 
     /*//////////////////////////////////////////////////////////////

--- a/test/AutoPxGmx.t.sol
+++ b/test/AutoPxGmx.t.sol
@@ -306,6 +306,8 @@ contract AutoPxGmxTest is Helper {
 
         assertEq(expectedPlatform, autoPxGmx.platform());
         assertTrue(expectedPlatform != initialPlatform);
+        assertEq(0, gmx.allowance(address(autoPxGmx), initialPlatform));
+        assertEq(type(uint256).max, gmx.allowance(address(autoPxGmx), platform));
     }
 
     /*//////////////////////////////////////////////////////////////


### PR DESCRIPTION
Changes to resolve issue #182 from the Code4rena audit. See here for more details: https://docs.google.com/document/d/1bmoKhOU2Rfgfirf_t-VZcp2oKlMawnSfcU5lEKtuNqc/edit.

AutoPxGlp
- Update `setPlatform` to set the previous platform's GMX base reward (i.e. WETH/WAVAX) transfer allowance to 0 and the new platform's allowance to the maximum integer value

AutoPxGmx
- Update `setPlatform` to set the previous platform's GMX transfer allowance to 0 and the new platform's allowance to the maximum integer value