### PR TITLE
C4 audit: resolve issue #264

### DIFF
--- a/src/vaults/AutoPxGlp.sol
+++ b/src/vaults/AutoPxGlp.sol
@@ -171,8 +171,8 @@ contract AutoPxGlp is PirexERC4626, PxGmxReward, ReentrancyGuard {
     /**
         @notice Preview the amount of shares a user would need to redeem the specified asset amount
         @notice This modified version takes into consideration the withdrawal fee
-        @param  assets   uint256  Assets amount
-        @return          uint256  Shares amount
+        @param  assets  uint256  Assets amount
+        @return         uint256  Shares amount
      */
     function previewWithdraw(uint256 assets)
         public
@@ -190,8 +190,10 @@ contract AutoPxGlp is PirexERC4626, PxGmxReward, ReentrancyGuard {
         return
             (_totalSupply == 0 || _totalSupply - shares == 0)
                 ? shares
-                : (shares * FEE_DENOMINATOR) /
-                    (FEE_DENOMINATOR - withdrawalPenalty);
+                : shares.mulDivUp(
+                    FEE_DENOMINATOR,
+                    FEE_DENOMINATOR - withdrawalPenalty
+                );
     }
 
     /**

--- a/src/vaults/AutoPxGmx.sol
+++ b/src/vaults/AutoPxGmx.sol
@@ -193,8 +193,8 @@ contract AutoPxGmx is ReentrancyGuard, Owned, PirexERC4626 {
     /**
         @notice Preview the amount of shares a user would need to redeem the specified asset amount
         @notice This modified version takes into consideration the withdrawal fee
-        @param  assets  uint256  Assets
-        @return uint256  Shares
+        @param  assets   uint256  Assets
+        @return          uint256  Shares
      */
     function previewWithdraw(uint256 assets)
         public
@@ -212,8 +212,10 @@ contract AutoPxGmx is ReentrancyGuard, Owned, PirexERC4626 {
         return
             (_totalSupply == 0 || _totalSupply - shares == 0)
                 ? shares
-                : (shares * FEE_DENOMINATOR) /
-                    (FEE_DENOMINATOR - withdrawalPenalty);
+                : shares.mulDivUp(
+                    FEE_DENOMINATOR,
+                    FEE_DENOMINATOR - withdrawalPenalty
+                );
     }
 
     /**


### PR DESCRIPTION
Changes to resolve issue #182 from the Code4rena audit. See here for more details: https://docs.google.com/document/d/1bmoKhOU2Rfgfirf_t-VZcp2oKlMawnSfcU5lEKtuNqc/edit.

AutoPxGmx and AutoPxGlp
- Recover the rounding up behavior which was previously implemented in ERC-4626's `previewWithdraw` by using the [FixedPointMathLib library's `mulDivUp` method](https://github.com/transmissions11/solmate/blob/main/src/utils/FixedPointMathLib.sol#L53)