### PR TITLE
C4 audit: resolve issue #97

### DIFF
--- a/src/PirexGmx.sol
+++ b/src/PirexGmx.sol
@@ -515,6 +515,8 @@ contract PirexGmx is ReentrancyGuard, Owned, Pausable {
 
             // Intake user ERC20 tokens and approve GLP Manager contract for amount
             t.safeTransferFrom(msg.sender, address(this), tokenAmount);
+            // Reset allowances before approving using the new amount
+            t.safeApprove(glpManager, 0);
             t.safeApprove(glpManager, tokenAmount);
 
             // Mint and stake GLP using ERC20 tokens

--- a/src/PirexGmx.sol
+++ b/src/PirexGmx.sol
@@ -515,8 +515,6 @@ contract PirexGmx is ReentrancyGuard, Owned, Pausable {
 
             // Intake user ERC20 tokens and approve GLP Manager contract for amount
             t.safeTransferFrom(msg.sender, address(this), tokenAmount);
-            // Reset allowances before approving using the new amount
-            t.safeApprove(glpManager, 0);
             t.safeApprove(glpManager, tokenAmount);
 
             // Mint and stake GLP using ERC20 tokens

--- a/src/vaults/AutoPxGlp.sol
+++ b/src/vaults/AutoPxGlp.sol
@@ -201,6 +201,22 @@ contract AutoPxGlp is PirexERC4626, PxGmxReward, ReentrancyGuard {
     }
 
     /**
+        @notice Return the maximum amount of assets the specified account can withdraw
+        @param  account  address  Account address
+        @return          uint256  Assets
+     */
+    function maxWithdraw(address account)
+        public
+        view
+        override
+        returns (uint256)
+    {
+        uint256 shares = balanceOf[account];
+
+        return previewRedeem(shares);
+    }
+
+    /**
         @notice Compound pxGLP (and additionally pxGMX) rewards
         @param  minUsdg                uint256  Minimum USDG amount used when minting GLP
         @param  minGlp                 uint256  Minimum GLP amount received from the WETH deposit

--- a/src/vaults/AutoPxGlp.sol
+++ b/src/vaults/AutoPxGlp.sol
@@ -394,6 +394,8 @@ contract AutoPxGlp is PirexERC4626, PxGmxReward, ReentrancyGuard {
 
         // Approve as needed here since it can be a new whitelisted token (unless it's the baseReward)
         if (erc20Token != gmxBaseReward) {
+            // Reset allowances before approving using the new amount
+            erc20Token.safeApprove(platform, 0);
             erc20Token.safeApprove(platform, tokenAmount);
         }
 

--- a/src/vaults/AutoPxGlp.sol
+++ b/src/vaults/AutoPxGlp.sol
@@ -211,9 +211,7 @@ contract AutoPxGlp is PirexERC4626, PxGmxReward, ReentrancyGuard {
         override
         returns (uint256)
     {
-        uint256 shares = balanceOf[account];
-
-        return previewRedeem(shares);
+        return previewRedeem(balanceOf[account]);
     }
 
     /**

--- a/src/vaults/AutoPxGlp.sol
+++ b/src/vaults/AutoPxGlp.sol
@@ -410,8 +410,6 @@ contract AutoPxGlp is PirexERC4626, PxGmxReward, ReentrancyGuard {
 
         // Approve as needed here since it can be a new whitelisted token (unless it's the baseReward)
         if (erc20Token != gmxBaseReward) {
-            // Reset allowances before approving using the new amount
-            erc20Token.safeApprove(platform, 0);
             erc20Token.safeApprove(platform, tokenAmount);
         }
 

--- a/src/vaults/AutoPxGmx.sol
+++ b/src/vaults/AutoPxGmx.sol
@@ -233,9 +233,7 @@ contract AutoPxGmx is ReentrancyGuard, Owned, PirexERC4626 {
         override
         returns (uint256)
     {
-        uint256 shares = balanceOf[account];
-
-        return previewRedeem(shares);
+        return previewRedeem(balanceOf[account]);
     }
 
     /**

--- a/src/vaults/AutoPxGmx.sol
+++ b/src/vaults/AutoPxGmx.sol
@@ -223,6 +223,22 @@ contract AutoPxGmx is ReentrancyGuard, Owned, PirexERC4626 {
     }
 
     /**
+        @notice Return the maximum amount of assets the specified account can withdraw
+        @param  account  address  Account address
+        @return          uint256  Assets
+     */
+    function maxWithdraw(address account)
+        public
+        view
+        override
+        returns (uint256)
+    {
+        uint256 shares = balanceOf[account];
+
+        return previewRedeem(shares);
+    }
+
+    /**
         @notice Compound pxGMX rewards before depositing
      */
     function beforeDeposit(

--- a/test/AutoPxGlp.t.sol
+++ b/test/AutoPxGlp.t.sol
@@ -3,15 +3,12 @@ pragma solidity 0.8.17;
 
 import "forge-std/Test.sol";
 
-import {FixedPointMathLib} from "solmate/utils/FixedPointMathLib.sol";
 import {AutoPxGlp} from "src/vaults/AutoPxGlp.sol";
 import {PirexGmx} from "src/PirexGmx.sol";
 import {PxGmxReward} from "src/vaults/PxGmxReward.sol";
 import {Helper} from "./Helper.sol";
 
 contract AutoPxGlpTest is Helper {
-    using FixedPointMathLib for uint256;
-
     event Deposit(
         address indexed caller,
         address indexed owner,
@@ -617,10 +614,7 @@ contract AutoPxGlpTest is Helper {
         uint256 maxWithdrawAmount = autoPxGlp.maxWithdraw(account);
         uint256 expectedPenalty = autoPxGlp
             .convertToAssets(shareBalance)
-            .mulDivDown(
-                autoPxGlp.withdrawalPenalty(),
-                autoPxGlp.FEE_DENOMINATOR()
-            );
+            - autoPxGlp.previewRedeem(shareBalance);
         uint256 expectedMaxWithdrawAmount = shareBalance - expectedPenalty;
 
         assertEq(expectedMaxWithdrawAmount, maxWithdrawAmount);

--- a/test/AutoPxGmx.t.sol
+++ b/test/AutoPxGmx.t.sol
@@ -3,11 +3,14 @@ pragma solidity 0.8.17;
 
 import "forge-std/Test.sol";
 
+import {FixedPointMathLib} from "solmate/utils/FixedPointMathLib.sol";
 import {AutoPxGmx} from "src/vaults/AutoPxGmx.sol";
 import {PirexGmx} from "src/PirexGmx.sol";
 import {Helper} from "./Helper.sol";
 
 contract AutoPxGmxTest is Helper {
+    using FixedPointMathLib for uint256;
+
     event PoolFeeUpdated(uint24 _poolFee);
     event Compounded(
         address indexed caller,
@@ -73,6 +76,19 @@ contract AutoPxGmxTest is Helper {
 
         wethRewardState = pirexRewards.getRewardState(pxGmx, weth);
         pxGmxRewardState = pirexRewards.getRewardState(pxGmx, pxGmx);
+    }
+
+    /**
+        @notice Previously faulty version of maxWithdraw
+        @param  account  address  Account address
+        @return          uint256  Max withdraw amount
+     */
+    function _maxWithdrawFaulty(address account)
+        internal
+        view
+        returns (uint256)
+    {
+        return autoPxGmx.convertToAssets(autoPxGmx.balanceOf(account));
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -307,7 +323,10 @@ contract AutoPxGmxTest is Helper {
         assertEq(expectedPlatform, autoPxGmx.platform());
         assertTrue(expectedPlatform != initialPlatform);
         assertEq(0, gmx.allowance(address(autoPxGmx), initialPlatform));
-        assertEq(type(uint256).max, gmx.allowance(address(autoPxGmx), platform));
+        assertEq(
+            type(uint256).max,
+            gmx.allowance(address(autoPxGmx), platform)
+        );
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -329,6 +348,49 @@ contract AutoPxGmxTest is Helper {
 
         assertEq(expectedTotalAssets, autoPxGmx.totalAssets());
         assertTrue(expectedTotalAssets != initialTotalAssets);
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                        maxWithdraw TESTS
+    //////////////////////////////////////////////////////////////*/
+
+    /**
+        @notice  Test tx success: return the maximum withdrawable assets
+    */
+    function testMaxWithdraw() external {
+        // Perform deposits for all test accounts first
+        uint256 gmxAmount = 10e18;
+        uint256 secondsElapsed = 1 weeks;
+        address[] memory receivers = new address[](testAccounts.length);
+        for (uint256 i; i < testAccounts.length; ++i) {
+            receivers[i] = testAccounts[i];
+        }
+
+        (, , uint256[] memory shareBalances) = _provisionRewardState(
+            gmxAmount,
+            receivers,
+            secondsElapsed
+        );
+
+        // Check max withdrawal for one of the test accounts
+        uint256 faultyMaxWithdrawAmount = _maxWithdrawFaulty(receivers[0]);
+        uint256 maxWithdrawAmount = autoPxGmx.maxWithdraw(receivers[0]);
+        uint256 expectedPenalty = autoPxGmx
+            .convertToAssets(shareBalances[0])
+            .mulDivDown(
+                autoPxGmx.withdrawalPenalty(),
+                autoPxGmx.FEE_DENOMINATOR()
+            );
+        uint256 expectedMaxWithdrawAmount = shareBalances[0] - expectedPenalty;
+
+        assertEq(expectedMaxWithdrawAmount, maxWithdrawAmount);
+
+        // Assert that the faulty one results in larger amount (as it doesn't apply penalty)
+        assertLt(maxWithdrawAmount, faultyMaxWithdrawAmount);
+        assertEq(
+            expectedMaxWithdrawAmount,
+            faultyMaxWithdrawAmount - expectedPenalty
+        );
     }
 
     /*//////////////////////////////////////////////////////////////

--- a/test/AutoPxGmx.t.sol
+++ b/test/AutoPxGmx.t.sol
@@ -373,8 +373,9 @@ contract AutoPxGmxTest is Helper {
         );
 
         // Check max withdrawal for one of the test accounts
-        uint256 faultyMaxWithdrawAmount = _maxWithdrawFaulty(receivers[0]);
-        uint256 maxWithdrawAmount = autoPxGmx.maxWithdraw(receivers[0]);
+        address account = receivers[0];
+        uint256 faultyMaxWithdrawAmount = _maxWithdrawFaulty(account);
+        uint256 maxWithdrawAmount = autoPxGmx.maxWithdraw(account);
         uint256 expectedPenalty = autoPxGmx
             .convertToAssets(shareBalances[0])
             .mulDivDown(

--- a/test/AutoPxGmx.t.sol
+++ b/test/AutoPxGmx.t.sol
@@ -3,14 +3,11 @@ pragma solidity 0.8.17;
 
 import "forge-std/Test.sol";
 
-import {FixedPointMathLib} from "solmate/utils/FixedPointMathLib.sol";
 import {AutoPxGmx} from "src/vaults/AutoPxGmx.sol";
 import {PirexGmx} from "src/PirexGmx.sol";
 import {Helper} from "./Helper.sol";
 
 contract AutoPxGmxTest is Helper {
-    using FixedPointMathLib for uint256;
-
     event PoolFeeUpdated(uint24 _poolFee);
     event Compounded(
         address indexed caller,
@@ -376,12 +373,8 @@ contract AutoPxGmxTest is Helper {
         address account = receivers[0];
         uint256 faultyMaxWithdrawAmount = _maxWithdrawFaulty(account);
         uint256 maxWithdrawAmount = autoPxGmx.maxWithdraw(account);
-        uint256 expectedPenalty = autoPxGmx
-            .convertToAssets(shareBalances[0])
-            .mulDivDown(
-                autoPxGmx.withdrawalPenalty(),
-                autoPxGmx.FEE_DENOMINATOR()
-            );
+        uint256 expectedPenalty = autoPxGmx.convertToAssets(shareBalances[0]) -
+            autoPxGmx.previewRedeem(shareBalances[0]);
         uint256 expectedMaxWithdrawAmount = shareBalances[0] - expectedPenalty;
 
         assertEq(expectedMaxWithdrawAmount, maxWithdrawAmount);

--- a/test/Helper.sol
+++ b/test/Helper.sol
@@ -466,7 +466,7 @@ contract Helper is Test, HelperEvents, HelperState {
         vm.deal(receiver, ethAmount);
         vm.startPrank(receiver);
 
-        fsGlp = REWARD_ROUTER_V2.mintAndStakeGlpETH{value: ethAmount}(1, 1);
+        fsGlp = GLP_REWARD_ROUTER_V2.mintAndStakeGlpETH{value: ethAmount}(1, 1);
 
         vm.warp(block.timestamp + 1 hours);
 


### PR DESCRIPTION
Changes to resolve issue #97 from the Code4rena audit. See here for more details: [https://docs.google.com/document/d/1bmoKhOU2Rfgfirf_t-VZcp2oKlMawnSfcU5lEKtuNqc/edit](https://docs.google.com/document/d/1bmoKhOU2Rfgfirf_t-VZcp2oKlMawnSfcU5lEKtuNqc/edit).

`AutoPxGmx` and `AutoPxGlp`

- Update `maxWithdraw` in both vaults to take into accounts withdrawal penalty. Note that it is still subject to the same issue as outlined at issue #191 which has been acknowledged. (#97)