### PR TITLE
C4 audit: resolve issue #196, #214, and #237

### DIFF
--- a/src/PirexGmx.sol
+++ b/src/PirexGmx.sol
@@ -280,11 +280,6 @@ contract PirexGmx is ReentrancyGuard, Owned, Pausable {
         @notice Initialize GMX contract state
      */
     function initializeGmxState() external onlyOwner whenPaused {
-        // Revoke old staker contract's GMX approval
-        if (address(stakedGmx) != address(0)) {
-            gmx.safeApprove(address(stakedGmx), 0);
-        }
-
         // Variables which can be assigned by reading previously-set GMX contracts
         rewardTrackerGmx = RewardTracker(gmxRewardRouterV2.feeGmxTracker());
         rewardTrackerGlp = RewardTracker(glpRewardRouterV2.feeGlpTracker());

--- a/src/PirexGmx.sol
+++ b/src/PirexGmx.sol
@@ -250,6 +250,10 @@ contract PirexGmx is ReentrancyGuard, Owned, Pausable {
             r = useGmx ? stakedGmx : feeStakedGlp;
         }
 
+        uint256 totalSupply = r.totalSupply();
+
+        if (totalSupply == 0) return 0;
+
         address distributor = r.distributor();
         uint256 pendingRewards = IRewardDistributor(distributor)
             .pendingRewards();
@@ -260,7 +264,7 @@ contract PirexGmx is ReentrancyGuard, Owned, Pausable {
             : pendingRewards;
         uint256 precision = r.PRECISION();
         uint256 cumulativeRewardPerToken = r.cumulativeRewardPerToken() +
-            ((blockReward * precision) / r.totalSupply());
+            ((blockReward * precision) / totalSupply);
 
         if (cumulativeRewardPerToken == 0) return 0;
 

--- a/src/PirexGmx.sol
+++ b/src/PirexGmx.sol
@@ -513,14 +513,22 @@ contract PirexGmx is ReentrancyGuard, Owned, Pausable {
         } else {
             ERC20 t = ERC20(token);
 
-            // Intake user ERC20 tokens and approve GLP Manager contract for amount
+            uint256 preTransferBalance = t.balanceOf(address(this));
+
+            // Intake user ERC20 tokens
             t.safeTransferFrom(msg.sender, address(this), tokenAmount);
-            t.safeApprove(glpManager, tokenAmount);
+
+            uint256 transferredAmount = t.balanceOf(address(this)) - preTransferBalance;
+
+            if (transferredAmount == 0) revert ZeroAmount();
+
+            // Approve GLP Manager contract with the actual amount transferred
+            t.safeApprove(glpManager, transferredAmount);
 
             // Mint and stake GLP using ERC20 tokens
             deposited = glpRewardRouterV2.mintAndStakeGlp(
                 token,
-                tokenAmount,
+                transferredAmount,
                 minUsdg,
                 minGlp
             );

--- a/src/PirexGmx.sol
+++ b/src/PirexGmx.sol
@@ -85,7 +85,7 @@ contract PirexGmx is ReentrancyGuard, Owned, Pausable {
     // Fees (e.g. 5000 / 1000000 = 0.5%)
     mapping(Fees => uint256) public fees;
 
-    event ConfigureGmxState(
+    event InitializeGmxState(
         address indexed caller,
         RewardTracker rewardTrackerGmx,
         RewardTracker rewardTrackerGlp,
@@ -277,9 +277,9 @@ contract PirexGmx is ReentrancyGuard, Owned, Pausable {
     }
 
     /**
-        @notice Configure GMX contract state
+        @notice Initialize GMX contract state
      */
-    function configureGmxState() external onlyOwner whenPaused {
+    function initializeGmxState() external onlyOwner whenPaused {
         // Revoke old staker contract's GMX approval
         if (address(stakedGmx) != address(0)) {
             gmx.safeApprove(address(stakedGmx), 0);
@@ -293,7 +293,7 @@ contract PirexGmx is ReentrancyGuard, Owned, Pausable {
         glpManager = glpRewardRouterV2.glpManager();
         gmxVault = IVault(IGlpManager(glpManager).vault());
 
-        emit ConfigureGmxState(
+        emit InitializeGmxState(
             msg.sender,
             rewardTrackerGmx,
             rewardTrackerGlp,

--- a/src/PirexGmx.sol
+++ b/src/PirexGmx.sol
@@ -276,6 +276,11 @@ contract PirexGmx is ReentrancyGuard, Owned, Pausable {
         @notice Configure GMX contract state
      */
     function configureGmxState() external onlyOwner whenPaused {
+        // Revoke old staker contract's GMX approval
+        if (address(stakedGmx) != address(0)) {
+            gmx.safeApprove(address(stakedGmx), 0);
+        }
+
         // Variables which can be assigned by reading previously-set GMX contracts
         rewardTrackerGmx = RewardTracker(gmxRewardRouterV2.feeGmxTracker());
         rewardTrackerGlp = RewardTracker(glpRewardRouterV2.feeGlpTracker());

--- a/src/vaults/AutoPxGlp.sol
+++ b/src/vaults/AutoPxGlp.sol
@@ -387,19 +387,24 @@ contract AutoPxGlp is PirexERC4626, PxGmxReward, ReentrancyGuard {
 
         // PirexGmx will do the check whether the token is whitelisted or not
         ERC20 erc20Token = ERC20(token);
+        uint256 preTransferBalance = erc20Token.balanceOf(address(this));
 
         // Transfer token from the caller to the vault
         // before approving PirexGmx to proceed with the deposit
         erc20Token.safeTransferFrom(msg.sender, address(this), tokenAmount);
 
+        uint256 transferredAmount = erc20Token.balanceOf(address(this)) - preTransferBalance;
+
+        if (transferredAmount == 0) revert ZeroAmount();
+
         // Approve as needed here since it can be a new whitelisted token (unless it's the baseReward)
         if (erc20Token != gmxBaseReward) {
-            erc20Token.safeApprove(platform, tokenAmount);
+            erc20Token.safeApprove(platform, transferredAmount);
         }
 
         (, uint256 assets, ) = PirexGmx(platform).depositGlp(
             token,
-            tokenAmount,
+            transferredAmount,
             minUsdg,
             minGlp,
             address(this)

--- a/test/Helper.sol
+++ b/test/Helper.sol
@@ -185,8 +185,8 @@ contract Helper is Test, HelperEvents, HelperState {
         pxGlp.grantRole(pxGlp.BURNER_ROLE(), address(pirexGmx));
         pirexRewards.setProducer(address(pirexGmx));
 
-        // Configure GMX state and unpause
-        pirexGmx.configureGmxState();
+        // Initialize GMX state and unpause
+        pirexGmx.initializeGmxState();
         pirexGmx.setPauseState(false);
 
         feeMax = pirexGmx.FEE_MAX();

--- a/test/HelperEvents.sol
+++ b/test/HelperEvents.sol
@@ -9,7 +9,7 @@ import {IVault} from "src/interfaces/IVault.sol";
 
 contract HelperEvents {
     // PirexGmx events
-    event ConfigureGmxState(
+    event InitializeGmxState(
         address indexed caller,
         RewardTracker rewardTrackerGmx,
         RewardTracker rewardTrackerGlp,

--- a/test/PirexGmx.t.sol
+++ b/test/PirexGmx.t.sol
@@ -100,36 +100,36 @@ contract PirexGmxTest is Test, Helper {
     }
 
     /*//////////////////////////////////////////////////////////////
-                            configureGmxState TESTS
+                            initializeGmxState TESTS
     //////////////////////////////////////////////////////////////*/
 
     /**
         @notice Test tx reversion: caller is unauthorized
      */
-    function testCannotConfigureGmxStateUnauthorized() external {
+    function testCannotInitializeGmxStateUnauthorized() external {
         address unauthorizedCaller = _getUnauthorizedCaller();
 
         vm.expectRevert(UNAUTHORIZED_ERROR);
         vm.prank(unauthorizedCaller);
 
-        pirexGmx.configureGmxState();
+        pirexGmx.initializeGmxState();
     }
 
     /**
         @notice Test tx reversion: contract is not paused
      */
-    function testCannotConfigureGmxStateNotPaused() external {
+    function testCannotInitializeGmxStateNotPaused() external {
         assertEq(false, pirexGmx.paused());
 
         vm.expectRevert(NOT_PAUSED_ERROR);
 
-        pirexGmx.configureGmxState();
+        pirexGmx.initializeGmxState();
     }
 
     /**
         @notice Test tx success: configure GMX state
      */
-    function testConfigureGmxState() external {
+    function testInitializeGmxState() external {
         PirexGmx freshPirexGmx = new PirexGmx(
             address(pxGmx),
             address(pxGlp),
@@ -159,7 +159,7 @@ contract PirexGmxTest is Test, Helper {
 
         vm.expectEmit(true, false, false, true, address(freshPirexGmx));
 
-        emit ConfigureGmxState(
+        emit InitializeGmxState(
             address(this),
             rewardTrackerGmx,
             rewardTrackerGlp,
@@ -169,7 +169,7 @@ contract PirexGmxTest is Test, Helper {
             gmxVault
         );
 
-        freshPirexGmx.configureGmxState();
+        freshPirexGmx.initializeGmxState();
 
         assertEq(
             address(rewardTrackerGmx),


### PR DESCRIPTION
Changes to resolve issue #196, #214 and #237 from the Code4rena audit. See here for more details: [https://docs.google.com/document/d/1bmoKhOU2Rfgfirf_t-VZcp2oKlMawnSfcU5lEKtuNqc/edit](https://docs.google.com/document/d/1bmoKhOU2Rfgfirf_t-VZcp2oKlMawnSfcU5lEKtuNqc/edit).

`AutoPxGlp` and `PirexGmx`

- Take into account potential transfer fees on any ERC20 tokens by using balance difference in-between the transfer call to get accurate deposited amount (applies to both `_depositGlp` in `PirexGmx` as well as `depositGlp` in `AutoPxGlp`) (#196)

`PirexGmx`

- Update naming for `configureGmxState` to `initializeGmxState`. (#214)
- Check for `totalSupply` from any of the reward tracker contracts before using it as divisor in `_calculateRewards`. (#237)